### PR TITLE
Now passing the x-iota-api-version header

### DIFF
--- a/lib/iotaproxy.js
+++ b/lib/iotaproxy.js
@@ -114,6 +114,15 @@ let iotaProxy =
                     'Content-Type': request.headers['content-type'],
                     'Content-Length': requestbody.length
                   };
+                  // Make sure the x-iota-api-version header is also passed along,
+                  // no matter the casing used for this header.
+                  Object.keys(request.headers).forEach(function(key)
+                  {
+                    if (key.toLowerCase() === 'x-iota-api-version')
+                    {
+                      proxyRequestOptions.headers[key] = request.headers[key];
+                    }
+                  });
                 }
 
                 let proxyRequest = http.request(


### PR DESCRIPTION
Using the following code:

```
var IOTA = require('iota.lib.js');

let iotaDirect = new IOTA({ provider: 'http://iotatoken.nl:14265' });
let iotaProxy = new IOTA({ provider: 'http://localhost:14265' });

iotaDirect.api.getNodeInfo(function(error, res) {
    if (error) {
        console.error('direct - error:', error.toString());
    } else {
        console.info('direct - success. version is:', res.appVersion);
    }
});

iotaProxy.api.getNodeInfo(function(error, res) {
    if (error) {
        console.error('proxy - error:', error.toString());
    } else {
        console.info('proxy - success. version is:', res.appVersion);
    }
});
```

I get the following output:

```
$ node src/test.js
direct - success. version is: 1.4.1.1
proxy - error: Error: Request Error: Invalid API Version
```

It turns out that this error can be solved by making sure the proxy passes on the `x-iota-api-version`. This PR contains a fix. I've tried to follow your coding style; hope it's good enough.