### PR TITLE
Added header for new IOTA API version

### DIFF
--- a/lib/iotaproxy.js
+++ b/lib/iotaproxy.js
@@ -112,6 +112,7 @@ let iotaProxy =
                   proxyRequestOptions.headers =
                   {
                     'Content-Type': request.headers['content-type'],
+                    'X-IOTA-API-Version': '1.4.1',
                     'Content-Length': requestbody.length
                   };
                 }


### PR DESCRIPTION
Since recent IRI update it is mandatory to specify the API version in the headers. Otherwise response is declined with `Request Error: Invalid API Version`