### PR TITLE
basic implementation to enable remote iri over https

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Developers getting to know [iota.lib.js](https://github.com/iotaledger/iota.lib.
 "_COMMAND attachToTangle is not available on this node_" response after calling iota.api.sendTransfer().
 Some others may have experienced the same error message when calling the REST API [attachToTangle](https://iota.readme.io/docs/attachtotangle) command.
 The attachToTangle command is a request to perform the PoW that is necessary when doing a transaction.  
-  
+
 Most public full nodes in the IOTA network do not support the [attachToTangle](https://iota.readme.io/docs/attachtotangle) command.  
 By design it is expected that you do the PoW locally on your device, the network is not required to do this for you.  
 
@@ -30,7 +30,7 @@ and [ccurl](https://github.com/iotaledger/ccurl.git), and override the iota.api.
 
 > This repository contains code and precompiled libraries from [iotaledger/wallet](https://github.com/iotaledger/wallet).  
 > Licence: GNU General Public License v3.0
-  
+
 ---
 
 ## Prerequisites
@@ -64,8 +64,21 @@ and [ccurl](https://github.com/iotaledger/ccurl.git), and override the iota.api.
   var iotaProxy = require('./lib/iotaproxy.js');
   iotaProxy.start(
     {
-      host: 'http://iota.bitfinex.com', 
-      port: 80, 
+      host: 'iota.bitfinex.com',
+      port: 80,
+      protocol: "http:",
+      localPort: 14265,
+      overrideAttachToTangle: true
+    }
+  );
+  ```
+
+  or by using the provider setting:
+  ```
+  var iotaProxy = require('./lib/iotaproxy.js');
+  iotaProxy.start(
+    {
+      provider: "https://field.carriota.com:443",
       localPort: 14265,
       overrideAttachToTangle: true
     }
@@ -97,7 +110,7 @@ and [ccurl](https://github.com/iotaledger/ccurl.git), and override the iota.api.
     'port': 14265
   });
   ```
-  
 
-  
+
+
 ---

--- a/index.js
+++ b/index.js
@@ -11,8 +11,12 @@ var iotaProxy = require('./lib/iotaproxy.js');
 
 iotaProxy.start(
   {
-    host: 'http://iota.bitfinex.com',
-    port: 80,
+    // if provider is absent the host, port and protocol values will be used
+    // with sensible defaults
+    provider: '', // in the format "https://field.carriota.com:443"
+    host: 'iota.bitfinex.com', // the remote iri hostname
+    port: 80, // the port the remote iri is litening on
+    protocol: '',
     localPort: 14265,
     overrideAttachToTangle: true,
     timeout: 15

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ iotaProxy.start(
     provider: '', // in the format "https://field.carriota.com:443"
     host: 'iota.bitfinex.com', // the remote iri hostname
     port: 80, // the port the remote iri is litening on
-    protocol: '',
+    protocol: 'http:',
     localPort: 14265,
     overrideAttachToTangle: true,
     timeout: 15

--- a/lib/iotaproxy.js
+++ b/lib/iotaproxy.js
@@ -12,7 +12,9 @@
  */
 
 const http = require('http');
+const https = require('https');
 const ccurlProvider = require('./ccurlprovider.js');
+const { URL } = require('url');
 
 let iotaProxy =
 {
@@ -27,8 +29,52 @@ let iotaProxy =
   start: function(options)
   {
     let opts = options || {};
-    this.host = (opts.host ? opts.host : 'iota.bitfinex.com').replace('http://', '');
-    this.port = (opts.port ? opts.port : 80);
+
+    // create url from the supplied options
+    // if one can be set from the supplied options use that instead
+    // opts.provider is the most descriptive and portable, try for that first
+    if( opts.provider ){
+      console.log('Using provider: ' + opts.provider);
+      try {
+        let url = new URL(opts.provider);
+        this.host = url.host;
+        this.port = url.port;
+        this.protocol = url.protocol;
+      } catch(e) {
+        console.log('The supplied url \'' + opts.provider + '\' is malformed. Trying other variables and default options');
+      }
+      // if the opts.host is set use it
+    }else if( opts.host.length !== 0){
+      console.log('Using host option: '+ opts.host);
+      this.host = opts.host;
+
+      // if the opts.host is set try and use opts.port
+      if(  opts.port.length !== 0 ){
+        console.log('Using port option: '+ opts.port);
+        this.port = opts.port;
+      }else{
+        this.port = 80;
+        console.log('Using default port: 80');
+      }
+
+      // if the opts.host is set try and use opts.protocol
+      if(  opts.protocol.length !== 0 ){
+        console.log('Using protocol option: '+ opts.protocol);
+        this.protocol = opts.protocol;
+      }else{
+        this.protocol = 'http:';
+        console.log('Using default protocol: http');
+      }
+      // if no variables are set run with the default
+    }else{
+      // supply a default url
+      let url = new URL('http://iota.bitfinex.com');
+      console.log('no variables supplied, using default url ' + url.host);
+      this.host = url.host;
+      this.port = url.port;
+      this.protocol = url.protocol;
+    }
+
     this.localPort = (opts.localPort ? opts.localPort : 14265);
     this.overrideAttachToTangle = (opts.overrideAttachToTangle ? true : false);
     this.timeout = (opts.timeout ? opts.timeout : 15);
@@ -104,6 +150,7 @@ let iotaProxy =
                 {
                   hostname: that.host,
                   port: that.port,
+                  protocol: that.protocol,
                   path: request.url,
                   method: request.method
                 };
@@ -125,7 +172,16 @@ let iotaProxy =
                   });
                 }
 
-                let proxyRequest = http.request(
+                // switch here to turn on https
+                switch (that.protocol) {
+                  case 'https:':
+                    var transport = https;
+                    break;
+                  default:
+                    var transport = http;
+                }
+
+                let proxyRequest = transport.request(
                   proxyRequestOptions,
                   function (proxyResponse)
                   {
@@ -183,7 +239,7 @@ let iotaProxy =
     console.log('IOTA proxy server started');
     console.log('POW timeout is set to ' + this.timeout + ' min');
     console.log('Listening on port ' + this.localPort);
-    console.log('Relaying requests to ' + this.host + ':' + this.port);
+    console.log('Relaying requests to '+ this.protocol + '//' + this.host + ':' + this.port);
 
   },
 


### PR DESCRIPTION
These changes enable the user to supply an https url for the remote iri. 
This works by adding two options to the configuration - provider and protocol. This enables the user to supply a single configuration string e.g. "https://field.carriota.com:443" or the current way with host, port and now protocol. The existing configuration options will still work.
If host is populated, then port and protocol are optional and default to port 80 and http:
When the request to the remote iri service begins it uses the appropriate http or https method. 
I haven't supplied any tests yet but will if i continue to build on the s/w. 